### PR TITLE
Don't commit updated license notice file automatically

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
       - name: Clone License Check Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/license-check
-          ref: v1
+          ref: v1.2.0
           path: .github/actions/license-check
 
       - id: run-license-checker

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -30,6 +30,7 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |actions/checkout|v2|MIT License|
+|actions/checkout|v3|MIT License|
 |actions/setup-node|v2.4.1|MIT License|
 |actions/upload-artifact|v2|MIT License|
 |pre-commit/action|v3.0.0|MIT License|


### PR DESCRIPTION
Automatically committing an updated notice file is not working well in the Eclipse environment.
With this fix an updated notice file is notified as warning in the CI workflow and uploaded as an build artefact.
The developer then has to manually add the updated content in his/her PR.

Ticket: AB#_10773_